### PR TITLE
Added test conditionals to block accordions

### DIFF
--- a/chrome-ext/panel/styles.css
+++ b/chrome-ext/panel/styles.css
@@ -37,3 +37,7 @@
   -webkit-flex: 1;
   flex: 1;
 }
+
+.accordion-block {
+  border: solid 1px black;
+}

--- a/client/actions/actionCreators.js
+++ b/client/actions/actionCreators.js
@@ -19,6 +19,15 @@ export function loadResults(payload) {
   }
 }
 
+export function saveResultToBlock(name, id, result) {
+  return {
+    type: 'SAVE_RESULT_TO_BLOCK', 
+    name,
+    id,
+    result
+  }
+}
+
 export function getNodeData(payload) {
   return {
     type: 'GET_NODE_DATA',

--- a/client/components/AssertionsList.js
+++ b/client/components/AssertionsList.js
@@ -50,16 +50,19 @@ class AssertionsList extends Component {
     let assertionlist = [];
     let listArray = this.props.stateIsNowProp.assertionList;
     if (listArray.length > 0) {
-      listArray.forEach((el, i) => {
-          assertionlist.push(
-            <Accordion.Title style={{'border': 'solid 1px black'}}>
+      listArray.forEach((block, i) => {
+        let styling;
+        if (block.passed === true) styling = ({'background': 'rgba(76, 175, 80, 0.8)', 'transition': 'all .25s ease-in'});
+        else if (block.passed === false) styling = ({'background': 'rgba(255, 0, 0, 0.8)', 'transition': 'all .25s ease-in'});
+        assertionlist.push(
+            <Accordion.Title style={styling} className='accordion-block'>
               <Icon name='dropdown' />
-              { el.name } 
-              <Icon name='delete' style={{'float': 'right'}} onClick={() => this.handleDelete(el.name)} />
+              { block.name } 
+              <Icon name='delete' style={{'float': 'right'}} onClick={() => this.handleDelete(block.name)} />
             </Accordion.Title>);
           assertionlist.push(
             <Accordion.Content >
-              {JSON.stringify(el.asserts)}
+              {JSON.stringify(block.asserts)}
             </Accordion.Content>);
       });
     }  

--- a/client/components/ReactTree.js
+++ b/client/components/ReactTree.js
@@ -44,7 +44,10 @@ class ReactTree extends Component {
           }
         }
         if (data.type === 'test-result') {
-          self.props.loadResults(data.data);
+          let resultObj = data.data;
+          self.props.loadResults(resultObj);
+          // Affect assertionList reducer to update results within the block
+          self.props.saveResultToBlock(resultObj.assertionBlock, resultObj.assertID, resultObj.result);
           console.log('d3 received results from content script', data.data);
         }
     });

--- a/client/reducers/assertionBlockReducer.js
+++ b/client/reducers/assertionBlockReducer.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 
-function assertionBlockReducer(state = { name: '', asserts: [] }, action) {
+function assertionBlockReducer(state = { name: '', passed:'', asserts: [], results: {} }, action) {
   let newState;
   // console.log('in assertion block reducer');
   switch(action.type) {
@@ -13,7 +13,7 @@ function assertionBlockReducer(state = { name: '', asserts: [] }, action) {
       newState = Object.assign({}, state);
       newState.asserts = state.asserts.slice();
       newState.asserts.push(action.payload);
-      return newState;  
+      return newState;
     case 'DELETE_ASSERTION':
       newState = Object.assign({}, state);
       newState.asserts = state.asserts.slice();

--- a/client/reducers/assertionListReducer.js
+++ b/client/reducers/assertionListReducer.js
@@ -9,7 +9,37 @@ function assertionListReducer(state = [], action){
       localStorage.setItem("asserts", JSON.stringify(newState));
       return newState;
     case 'LOAD_ASSERTION_LIST': 
-      return action.payload; 
+      return action.payload;
+    case 'SAVE_RESULT_TO_BLOCK':
+      newState = state.slice();
+      // iterate through each block
+      for (let i = 0; i < newState.length; i += 1) {
+        if (newState[i].name === action.name) {
+          // Save result id - result pair to block
+          newState[i].results[action.id] = action.result;
+          // iterate through block's asserts and cross-reference with results
+          // if all asserts have a matching result of true, assign passed to true
+          let allPass = true;
+          for (let j = 0; j < newState[i].asserts.length; j += 1) {
+            const assertion = newState[i].asserts[j];
+            console.log('passed in result', action.result);
+            console.log('current assertion', assertion, assertion.assertID);
+            if (newState[i].results[assertion.assertID] === false) {
+              console.log('in fail conditional', newState[i].results[assertion.assertID])
+              allPass = false;
+              newState[i].passed = false;
+              break;
+            } else if (!newState[i].results[assertion.assertID] || newState[i].results[assertion.assertID] === '') {
+              allPass = false;
+              console.log('in empty conditional', newState[i].results[assertion.assertID]);
+            }
+          }
+          if (allPass === true) newState[i].passed = true;
+          break;
+        }
+      }
+      console.log('IN SAVE RESULT TO BLOCK', newState);
+      return newState;
     case 'DELETE_ASSERTION_BLOCK':
       newState = state.slice();
       for (let i = 0; i < newState.length; i += 1) {

--- a/client/reducers/testResultsReducer.js
+++ b/client/reducers/testResultsReducer.js
@@ -10,7 +10,7 @@ function testResultsReducer(state = {
   switch(action.type) {
     case 'LOAD_RESULTS':
       console.log('in reducertest', action.payload)
-      return action.payload; 
+      return action.payload;
     default:
       return state;
   }


### PR DESCRIPTION
- Added to assertionslist and assertionblock reducers to keep track of results
- Added passed property and result object (assertID - test result pair) to assertion block reducer
- Assertionslist action goes through goes through all asserts in a block and cross-references them with result keys to determine accordion green/red/white state

