### PR TITLE
Fixes and styling - see notes

### DIFF
--- a/chrome-ext/panel/styles.css
+++ b/chrome-ext/panel/styles.css
@@ -276,6 +276,13 @@ li {
   padding-top: 10px;
 }
 
+.button-container-right{
+  float: right;
+  margin-bottom: 10px;
+  padding-top: 10px;
+  padding-right: 42px;
+}
+
 .accordion-container {
   margin-top: 40px;
 }
@@ -400,17 +407,17 @@ rect {
 }
 
 .accordion-pass {
-  color: rgba(9,160,77,.85)!important;
+  color: rgba(19,140,97,1)!important;
   transition: all .2s ease-in!important;
 }
 
 .accordion-pass:hover {
-  color: rgba(19,140,97,1)!important;
+  color: rgba(8, 160, 77, 1)!important;
   transition: all .1s ease!important;
 }
 
 .accordion-fail {
-  color: rgba(255,0,0,.7)!important;
+  color: rgba(210, 0, 0, 0.70)!important;
   transition: all .2s ease-in!important;
 }
 

--- a/chrome-ext/panel/styles.css
+++ b/chrome-ext/panel/styles.css
@@ -261,8 +261,31 @@ li {
 
 .button-container{
   text-align: center;
-  margin-bottom: 10px;
+  background: #396083;
+  position: fixed;
+  top: 25vh;
+  width: 100%;
+  height: 40px;
+  padding-top: 5px;
+  z-index: 999;
 }
+
+.button-container-edit{
+  text-align: center;
+  margin-bottom: 10px;
+  padding-top: 10px;
+}
+
+.accordion-container {
+  margin-top: 40px;
+}
+
+/* #assertions-panel .btn-primary.new {
+  padding: 8px!important;
+  color: #C8CF50!important;
+  box-shadow: 0 0 0 2px #C8CF50 inset!important;
+  background: transparent!important;
+} */
 
 #nameBlockButton {
   margin-top: 10px;
@@ -278,8 +301,7 @@ rect {
 #assertions-panel {
   height: 55vh;
   background-color: #d5e0e5;    
-  overflow-y: auto;
-  padding-top: 10px;   
+  overflow-y: auto;   
 }
 
 .breadcrumb a:hover{
@@ -326,9 +348,6 @@ rect {
 /* .accordion-block {
   border: solid 1px black;
 } */
-.accordion-container {
-
-}
 
  .accordion-asserts {
   cursor: pointer;

--- a/chrome-ext/panel/styles.css
+++ b/chrome-ext/panel/styles.css
@@ -282,9 +282,19 @@ rect {
   padding-top: 10px;   
 }
 
+.breadcrumb a:hover{
+  cursor: unset!important;
+}
+
 .btn-primary {
   margin-right: 10px!important;
   margin-bottom: 10px!important;
+}
+
+#assertions-panel .btn-primary.back {
+  color: #2185d0;
+  box-shadow: 0 0 0 2px #2185d0 inset!important;
+  background-color: transparent;
 }
 
 #results-panel {

--- a/client/components/AddAssertionsForAction.js
+++ b/client/components/AddAssertionsForAction.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { render } from 'react-dom';
-import { Button, Input, Dropdown, Message } from 'semantic-ui-react';
+import { Button, Input, Dropdown, Message, Icon } from 'semantic-ui-react';
 
 class AddAssertionsForAction extends Component {
   constructor(props) {
@@ -90,9 +90,18 @@ class AddAssertionsForAction extends Component {
             { inputValueRender }
 
           </div>
-          
-          <Button inverted color="blue" size="tiny" type="button" onClick={()=>this.handleBack()} className="btn btn-primary">Back</Button>
-          <Button primary size="small" type="submit" className="btn btn-primary">Save</Button>
+          <Button animated visible inverted color="blue" size="tiny" primary type="button" onClick={()=>this.handleBack()} className="btn btn-primary back">
+            <Button.Content visible>Back</Button.Content>
+            <Button.Content hidden>
+              <Icon name='left arrow' />
+            </Button.Content>
+          </Button>
+          <Button animated primary type="submit" className="btn btn-primary">
+                <Button.Content visible>Save</Button.Content>
+                <Button.Content hidden>
+                  <Icon name='save' />
+                </Button.Content>
+            </Button>
           {this.error}
         </form>
       </div>

--- a/client/components/AssertionsList.js
+++ b/client/components/AssertionsList.js
@@ -127,8 +127,8 @@ class AssertionsList extends Component {
       return (
         <div>
           <div className='button-container'>
-            <Button primary size='mini' className="btn btn-primary" onClick={()=>this.handleNewAssertionBlock()}> New Assertion Block</Button>
-            <Button primary size='mini' type="button" className="btn btn-primary" onClick={()=>this.saveEnzyme()}> Export to Enzyme</Button>
+            <Button inverted color="yellow" primary size='mini' className="btn btn-primary new" onClick={()=>this.handleNewAssertionBlock()}> New Assertion Block</Button>
+            <Button inverted color="yellow" primary size='mini' type="button" className="btn btn-primary new" onClick={()=>this.saveEnzyme()}> Export to Enzyme</Button>
           </div>
           <div className="accordion-container">
             <Accordion styled>

--- a/client/components/AssertionsList.js
+++ b/client/components/AssertionsList.js
@@ -14,7 +14,8 @@ class AssertionsList extends Component {
     this.props.renderNameAssertionMode();
   }
 
-  handleDelete(name) {
+  handleDelete(e, name) {
+    e.stopPropagation();
     this.props.deleteAssertionBlock(name);
     this.props.stateIsNowProp.backgroundConnection.postMessage({
         type: 'assertion',
@@ -71,7 +72,7 @@ class AssertionsList extends Component {
             <Accordion.Title style={{'background': '#98AEC8'}} className={styling}>
               <Icon name='dropdown' />
               { block.name } 
-              <Icon name='delete' style={{'float': 'right'}} onClick={() => this.handleDelete(block.name)} />
+              <Icon name='delete' style={{'float': 'right'}} onClick={(e) => this.handleDelete(e, block.name)} />
             </Accordion.Title>);
         // loop through all asserts in block
         block.asserts.forEach((assertion, i)=> {

--- a/client/components/EditAssertionBlock.js
+++ b/client/components/EditAssertionBlock.js
@@ -1,19 +1,29 @@
 import React, { Component } from 'react';
 import { render } from 'react-dom';
-import { Button, Accordion, Icon } from 'semantic-ui-react';
+import { Button, Accordion, Icon, Message } from 'semantic-ui-react';
 
 class EditAssertionBlock extends Component {
   constructor(props) {
     super(props);
-    this.pageName = document.title;  
+    this.pageName = document.title; 
+    this.error = ''; 
   }
 
   handleSaveAssertionBlock() {
     console.log('IN EDIT BLOCK COMP ADD ASSERTIONBLOCK TO LIST', this.props.stateIsNowProp.assertionBlock)
-    this.props.resetAssertId();
-    this.props.addAssertionToList(this.props.stateIsNowProp.assertionBlock);
-    this.props.renderViewMode();
-    this.props.toggleAssertionBlock();
+
+    if (this.props.stateIsNowProp.assertionBlock.asserts.length === 0) {
+      this.error=(<Message negative>
+        <Message.Header>Assertions Required</Message.Header>
+        <p>Please create an action or test to continue.</p>
+</Message>);
+      this.forceUpdate();
+    } else {
+      this.props.resetAssertId();
+      this.props.addAssertionToList(this.props.stateIsNowProp.assertionBlock);
+      this.props.renderViewMode();
+      this.props.toggleAssertionBlock();
+    }
   }
 
   handleEdit() {
@@ -69,6 +79,7 @@ class EditAssertionBlock extends Component {
         </div>
         <div id='topNameEditBlock'>Assertion Block: {this.props.stateIsNowProp.assertionBlock.name} </div>
           { assertions }
+          { this.error }
       </div>
     )
   }

--- a/client/components/EditAssertionBlock.js
+++ b/client/components/EditAssertionBlock.js
@@ -61,7 +61,7 @@ class EditAssertionBlock extends Component {
     }
     return (
       <div>
-        <div className='button-container'>
+        <div className='button-container-edit'>
           <Button primary positive size="tiny" className="btn btn-primary" onClick={()=>this.handleSaveAssertionBlock()}>Save Assertion Block</Button> 
           <Button primary negative size="tiny" type="button" className="btn btn-primary" onClick={()=>this.handleCancel()}>Cancel</Button> 
           <Button primary  size="small" type="button" className="ui primary basic button" onClick={()=>this.props.renderActionMode()}>New Action</Button>

--- a/client/components/EditAssertionBlock.js
+++ b/client/components/EditAssertionBlock.js
@@ -47,7 +47,7 @@ class EditAssertionBlock extends Component {
       assertsArray.forEach((el, i) => {
         if (el.type === 'action') {
         assertions.push(
-          <div className='editAssert' onClick={()=> this.clickAction(el)}>{el.assertID} Action: { el.event } on {el.compName}</div>);
+          <div className='editAssert' onClick={()=> this.clickAction(el)}>{el.assertID} Action: { el.event } on {el.compName}<Icon name='delete' style={{'float': 'right'}} onClick={()=>this.handleDelete(el.assertID)} /></div>);
         } else {
           let evaluator; 
           if (el.type === 'equal') evaluator = 'Equal'; 
@@ -55,7 +55,7 @@ class EditAssertionBlock extends Component {
           if (el.type === 'lessthan') evaluator = 'be Less than'; 
           if (el.type === 'notequal') evaluator = 'not Equal'; 
           assertions.push(
-            <div className='editAssert' onClick={()=> this.clickTest(el)}>{el.assertID} Expect {el.selectorName} to {evaluator} {el.value}</div>);
+            <div className='editAssert' onClick={()=> this.clickTest(el)}>{el.assertID} Expect {el.selectorName} to {evaluator} {el.value}<Icon name='delete' style={{'float': 'right'}} onClick={()=>this.handleDelete(el.assertID)} /></div>);
         }
       });
     }

--- a/client/components/NameAssertionBlock.js
+++ b/client/components/NameAssertionBlock.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { render } from 'react-dom';
-import { Button, Input, Message } from 'semantic-ui-react';
+import { Button, Input, Message, Icon } from 'semantic-ui-react';
 
 
 class NameAssertionBlock extends Component {
@@ -30,6 +30,11 @@ class NameAssertionBlock extends Component {
       this.props.renderEditMode();
     } else this.forceUpdate();
   }
+
+  handleBack() {
+    this.props.renderViewMode();
+  }
+
   render() {
     return (
       <div id="newAssertionBlockDiv">
@@ -37,8 +42,21 @@ class NameAssertionBlock extends Component {
           this.saveHandler(event);
           }}>
           <h4>Assertion Block Name </h4>
-          <Input type="text" className="form-control" id="assertionBlockName" placeholder="Enter name" required ref="assertionBlockName" />
-          <Button id="nameBlockButton" primary size="tiny">Save Block</Button>
+          <Input type="text" className="form-control" id="assertionBlockName" placeholder="e.g. 'should render button'" required ref="assertionBlockName" />
+          <div className='button-container-right'>
+          <Button animated primary inverted color="red" size="tiny" type="button" onClick={()=>this.handleBack()} className="btn btn-primary">
+              <Button.Content visible>Cancel</Button.Content>
+              <Button.Content hidden>
+                <Icon name='delete' />
+              </Button.Content>
+            </Button>
+            <Button animated primary size="tiny" type="submit" className="btn btn-primary">
+                <Button.Content visible>Save</Button.Content>
+                <Button.Content hidden>
+                  <Icon name='save' />
+                </Button.Content>
+            </Button>
+          </div>
           <br />
           {this.error}
         </form>

--- a/client/components/ReactTree.js
+++ b/client/components/ReactTree.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import { render } from 'react-dom';
 import {ReactSVGPanZoom, setPointOnViewerCenter} from 'react-svg-pan-zoom';
 import { SortablePane, Pane } from 'react-sortable-pane';
-import { Dropdown } from 'semantic-ui-react'
+import { Dropdown, Loader } from 'semantic-ui-react'
 import Nodes from './Nodes.js';
 import Links from './Links.js';
 import Details from '../components/Details';
@@ -156,7 +156,7 @@ class ReactTree extends Component {
     if (this.props.stateIsNowProp.error === 'reactRouter') {
       return (<h1>React Router not supported</h1>);
     } else if (Object.keys(this.props.stateIsNowProp.treeData).length === 0) {
-        return (<h1>Waiting for Data</h1>);
+        return (<div><h1><Loader active inline /> Waiting for Data</h1></div>);
     } else {
         return (
    <div>

--- a/client/components/TestData.js
+++ b/client/components/TestData.js
@@ -214,7 +214,7 @@ class TestData extends Component {
           <br />
           <div id="chooseSourceMod">{ this.modifierRender }</div>  <div id="chooseSourceIndex">{ indexRender }</div>
         </div>
-        <Button animated primary type="button" onClick={()=>this.handleBack()} className="btn btn-primary">
+        <Button animated primary inverted color="blue" size="tiny" type="button" onClick={()=>this.handleBack()} className="btn btn-primary back">
             <Button.Content visible>Back</Button.Content>
             <Button.Content hidden>
               <Icon name='left arrow' />

--- a/client/components/TestExpect.js
+++ b/client/components/TestExpect.js
@@ -112,7 +112,7 @@ class TestExpect extends Component {
             { valueRender }
           </div>
           <div id="expectButtons">
-            <Button animated primary type="button" onClick={()=>this.handleBack()} className="btn btn-primary">
+            <Button animated primary inverted color="blue" size="tiny" type="button" onClick={()=>this.handleBack()} className="btn btn-primary back">
               <Button.Content visible>Back</Button.Content>
               <Button.Content hidden>
                 <Icon name='left arrow' />

--- a/client/components/TestLocation.js
+++ b/client/components/TestLocation.js
@@ -200,7 +200,7 @@ class TestLocation extends Component {
             { selectorModifierRender } { indexRender }
             </div>
           </div>
-          <Button animated primary type="button" onClick={()=>this.handleBack()} className="btn btn-primary">
+          <Button animated primary inverted color="blue" size="tiny" type="button" onClick={()=>this.handleBack()} className="btn btn-primary back">
             <Button.Content visible>Back</Button.Content>
             <Button.Content hidden>
               <Icon name='left arrow' />


### PR DESCRIPTION
- Styled back button
- Restore delete button for asserts in edit block panel
- Added loader to waiting page
- Create fixed menu for new assertion block/enzyme export buttons
- Added cancel button to assertion block name panel
- Edited styling of assertion block colors
- Added validation for saving a block without any assertions
- Fixed accordion opening after the one above it is deleted (use event.stopPropagation on delete handler) https://developer.mozilla.org/en-US/docs/Web/API/Event/stopPropagation
